### PR TITLE
build.yml: Lower build target to 2.2.0.29

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,5 @@
 name: GitHub-actions CI build runner - master branch against SFOS 2.2.0.29 (armv7hl only, because it is a `noarch` RPM)
 
-
 on:
   push:
     tags:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
       - '*'
   pull_request:
     branches:
-      - 'master'
+      - master
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,9 +19,9 @@ jobs:
       run: mkdir RPMS
 
     - name: Build armv7hl
-      uses: coderus/github-sfos-build@master
+      uses: coderus/github-sfos-build@old-stable
       with:
-        release: 4.1.0.24
+        release: 3.1.0.12
         arch: armv7hl
 
     - name: Upload build result

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,5 @@
-name: GitHub-actions CI build runner
+name: GitHub-actions CI build runner - master branch against SFOS 2.2.0.29 (armv7hl only, because it is a `noarch` RPM)
+
 
 on:
   push:
@@ -21,7 +22,7 @@ jobs:
     - name: Build armv7hl
       uses: coderus/github-sfos-build@old-stable
       with:
-        release: 3.1.0.12
+        release: 2.2.0.29
         arch: armv7hl
 
     - name: Upload build result


### PR DESCRIPTION
… which is the smallest and oldest available target for `coderus/github-sfos-build`, see https://hub.docker.com/r/coderus/sailfishos-platform-sdk/tags