### PR TITLE
spec file: Re-add `-q` to `%setup` macro

### DIFF
--- a/rpm/harbour-storeman-installer.spec
+++ b/rpm/harbour-storeman-installer.spec
@@ -49,7 +49,7 @@ Url:
 %endif
 
 %prep
-%setup
+%setup -q
 
 %build
 


### PR DESCRIPTION
… because `rpmlint` is complaining.