### PR TITLE
`master`→`v1.x.y-legacy`: Commits for v1.3.7 (#175)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@
 
 ### Background
 
-Starting with version 0.2.9, Storeman is built by the help of the SailfishOS-OBS and initially installed by the Storeman Installer (or manually).  To update from Storeman < 0.2.9, one must remove ("uninstall") Storeman *before* installing the Storeman Installer or manually installing Storeman ≥ 0.2.9.  After an initial installation of Storeman ≥ 0.2.9, further updates of Storeman will be performed within Storeman, as usual. 
+Starting with version 0.2.9, Storeman is built by the help of the SailfishOS-OBS and initially installed by the Storeman Installer (or manually).  To update from Storeman <&nbsp;0.2.9 (needs SailfishOS ≥&nbsp;3.1.0), one should reinstall Storeman via the Storeman Installer (which installs the current Storeman release, and since Storeman Installer 1.3.0 automatically removes a Storeman <&nbsp;0.3.0 before that) or manually remove Storeman <&nbsp;0.2.9 and install Storeman ≥&nbsp;0.3.0.  After an initial installation of Storeman ≥&nbsp;0.3.0, further updates of Storeman will be performed within Storeman, as usual.
 
-The Storeman Installer works on any SailfishOS release ≥ 3.1.0 and all supported CPU-architectures (armv7hl, i486 and aarch64).  The current Storeman Installer RPM can be obtained from [its "latest release" page at GitHub](https://github.com/storeman-developers/harbour-storeman-installer/releases/latest), [OpenRepos.net](https://openrepos.net/content/olf/storeman-installer) and [the SailfishOS-OBS](https://build.sailfishos.org/package/show/home:olf:harbour-storeman/harbour-storeman-installer).
+The Storeman Installer works on any SailfishOS release ≥&nbsp;3.1.0 and all supported CPU-architectures (armv7hl, i486 and aarch64).  The current Storeman Installer RPM can be obtained from [its "latest release" page at GitHub](https://github.com/storeman-developers/harbour-storeman-installer/releases/latest), [OpenRepos.net](https://openrepos.net/content/olf/storeman-installer) and [the SailfishOS-OBS](https://build.merproject.org/package/show/home:olf:harbour-storeman/harbour-storeman-installer).
 
 If you use the SailfishOS:Chum community repository, e.g., via [the SailfishOS:Chum GUI application](https://chumrpm.netlify.app/), you can install Storeman from there, without the indirection via Storeman Installer.
 
 The current RPMs of Storeman proper can be obtained for manual installation from [Storeman's releases section at GitHub](https://github.com/storeman-developers/harbour-storeman/releases); the RPMs of older Storeman releases are also available there, e.g., v0.1.8 which works on SailfishOS 2.2.1.<br />
-Alternatively the current RPMs of Storeman proper can be obtained from [the SailfishOS-OBS](https://build.sailfishos.org/project/show/home:olf:harbour-storeman).
+Alternatively the current RPMs of Storeman proper can be obtained from [the SailfishOS-OBS](https://build.merproject.org/project/show/home:olf:harbour-storeman).
 
 ### Important notes
 
@@ -22,8 +22,8 @@ Alternatively the current RPMs of Storeman proper can be obtained from [the Sail
 ### Installation instructions
 
 * Enable "System → Security → Untrusted software → Allow untrusted software" in the SailfishOS Settings app.
-* Download the current Storeman Installer RPM from [its "latest release" page at GitHub](https://github.com/storeman-developers/harbour-storeman-installer/releases/latest), [OpenRepos.net](https://openrepos.net/content/olf/storeman-installer) or [the SailfishOS-OBS](https://build.sailfishos.org/package/show/home:olf:harbour-storeman/harbour-storeman-installer).
+* Download the current Storeman Installer RPM from [its "latest release" page at GitHub](https://github.com/storeman-developers/harbour-storeman-installer/releases/latest), [OpenRepos.net](https://openrepos.net/content/olf/storeman-installer) or [the SailfishOS-OBS](https://build.merproject.org/package/show/home:olf:harbour-storeman/harbour-storeman-installer).
 * Tap on the "File downloaded" notification on your SailfishOS device or select the downloaded RPM file in a file-manager app and choose "Install" in its pulley menu; then confirm the installation.
-* Preferrably disable "Allow untrusted software" again.
-* Tap on the "Storeman Installer" icon on the device's app grid ("launcher") and wait until the Storeman installation finishes - the "Storeman Installer" icon should be replaced by the icon of Storeman proper, even though the icons look the same, their text is different.
+* Preferably disable "Allow untrusted software" again.
+* Tap on the "Storeman Installer" icon on the device's app grid ("launcher") and wait until the Storeman installation finishes - the "Storeman Installer" icon should be replaced by the icon of Storeman proper; even though the icons and their text look similarly on first sight, they are distinctively different.
 * The Storeman Installer is automatically removed ("uninstalled") when Storeman is being installed.

--- a/bin/harbour-storeman-installer
+++ b/bin/harbour-storeman-installer
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-pkcon repo-set-data harbour-storeman-obs refresh-now true
-pkcon -y install harbour-storeman
+pkcon -pn repo-set-data harbour-storeman-obs refresh-now true
+pkcon -pny install harbour-storeman

--- a/bin/harbour-storeman-installer
+++ b/bin/harbour-storeman-installer
@@ -24,52 +24,153 @@ export LC_ALL=POSIX  # For details see https://pubs.opengroup.org/onlinepubs/969
 # Nevertheless, this script is still a Bourne (not-"Again") Shell script and
 # shall stay free of bashisms.
 
-# This script is designed to be called as detached ("&") as the last statement
-# of the %posttrans section (the last executed) of an RPM spec file, or manually.
+# This script is designed to be called manually.
+mypid="$$"
 
 # Memorise how we were called:
 called="$(basename "$0")"
-
-# If logfile is already there, update its timestamp(s), else create it:
 logfile="/var/log/${called}.log.txt"
-if ! touch "$logfile"
-then printf '%s\n' "[Error] Failed to touch logfile $logfile" | systemd-cat -t "$called" -p 4 || true
+
+umask 7113  # The first octal digit is ignored by most implementations
+[ "$PWD" = /tmp ] || cd /tmp  # Set PWD to /tmp
+
+# Prefix first output with three linebreaks, if logfile size > 0
+linebreaks=""
+if [ -s "$logfile" ]
+then linebreaks="\n\n\n"
 fi
 
 # Write first entry to logfile:
-logentry="[Info] Touch'ed logfile: $logfile"
-if printf '%s\n' "$(date -Iseconds) $logentry" >> "$logfile"
+logentry="[Info] Logging to $logfile"
+if printf "${linebreaks}%s\n" "$(date -Iseconds) $logentry" >> "$logfile"
 then printf '%s\n' "$logentry" | systemd-cat -t "$called" -p 6 || true
-else printf '%s\n' "[Error] Failed to write to $logfile" | systemd-cat -t "$called" -p 4 || true
+else systemd-cat -t "$called" -p 4 printf '%s\n' "[Error] $pkgname failed to write to $logfile" || true
 fi
 
 # Even when started interactively, another pkcon job may have just been
 # started, hence provide pkcon with a little time to enqueue it, because
 # otherwise pkcon might fail enqueuing the next pkcon-job.
 sleep 1
-
-# `pkcon repo-set-data` is also intended to serve as a synchronisation
-# point, because most of pkcon's sub-commands wait until the package
-# management backend (on SailfishOS: RPM via libzypp) is idle:
-logentry="pkcon -pv repo-set-data harbour-storeman-obs refresh-now true"
-printf '\n%s\n' "$(date -Iseconds) [Step 1 / 2] $logentry" >> "$logfile" || true
-printf '%s\n' "[Debug] Execute: $logentry" | systemd-cat -t "$called" -p 7 || true
-if eval $logentry >> "$logfile" 2>&1
-then
-  # Sleeping for a second between the two pkcon calls, because pkcon *rarely*
-  # fails installing a package ("not found") immediately after a individual
-  # repository refresh via `repo-set-data <repo> refresh-now true`:
-  sleep 1
-  logentry="pkcon -pvy install harbour-storeman"
-  printf '\n%s\n' "$(date -Iseconds) [Step 2 / 2] $logentry" >> "$logfile" || true
-  printf '%s\n' "[Debug] Execute: $logentry" | systemd-cat -t "$called" -p 7 || true
-  # The following statement must be started detached ("&"), because this
-  # script file will be removed in the process, which will likely fail,
-  # if it is still opened for executing / reading.
-  # It also shall always be the last command issued (WRT control-flow).
-  eval $logentry >> "$logfile" 2>&1 &
-else
-  logentry="[Critical] Aborting to install harbour-storeman, because error-code $? was returned by: $logentry"
-  printf '\n%s\n\n\n' "$(date -Iseconds) $logentry" >> "$logfile" || true
-  printf '%s\n' "$logentry" | systemd-cat -t "$called" -p 3 || true
+# `pkcon search name` is also intended to serve as a synchronisation point,
+# because most of pkcon's sub-commands wait until the package management
+# backend (on SailfishOS: libzypp) is idle:
+if pkgname="$(pkcon -p search name "$called" | grep '^Installed ' | tr -s ' ' | cut -f 2 -d ' ' | rev | cut -f 2- -d '.' | rev | grep -m 1 "^$called-[0-9]")"
+then pkgkitd=ok
+else pkgkitd=KO
 fi
+
+# Write $pkgname to logfile:
+logentry="[Debug] Installed, now running: $pkgname"
+printf '\n%s\n' "$(date -Iseconds) $logentry" >> "$logfile" || true
+systemd-cat -t "$called" -p 7 printf '%s\n' "$logentry" || true
+
+# Out of occasional bad experience when pkcon is being hammered with
+# commands, also prefix `pkcon repo-set-data` with a second sleep:
+sleep 1
+maxi=4  # 4 is the minimal value, which makes sense here
+maxihalf=$(expr $maxi / 2)
+for i in $(seq $maxi)
+do
+  logentry="pkcon -pv repo-set-data harbour-storeman-obs refresh-now true"
+  printf '\n%s\n' "$(date -Iseconds) [Step 1 / 2] $logentry" >> "$logfile" || true
+  systemd-cat -t "$called" -p 7 printf '%s\n' "[Debug] Execute: $logentry" || true
+  eval $logentry >> "$logfile" 2>&1
+  retc=$?
+  wait=$(expr $i \* 2 + 1)
+  if [ $retc = 0 ]
+  then break  # Went fine
+  elif [ $i = 1 ]
+  then
+    logentry="[Warning] Failed to refresh harbour-storeman-obs repository, because error-code $retc was returned by: $logentry"
+    printf '\n%s\n' "$(date -Iseconds) $logentry" >> "$logfile" || true
+    printf '%s\n' "$logentry" | systemd-cat -t "$called" -p 5 || true
+    logentry="[Debug] Sleeping for $wait seconds."
+    printf '\n%s\n' "$(date -Iseconds) $logentry" >> "$logfile" || true
+    systemd-cat -t "$called" -p 7 printf '%s\n' "$logentry" || true
+    sleep $wait
+    logentry="[Info] Retry #$i"
+    printf '\n%s\n' "$(date -Iseconds) $logentry" >> "$logfile" || true
+    systemd-cat -t "$called" -p 6 printf '%s\n' "$logentry" || true
+  elif [ $i -le $maxihalf ]
+  then
+    logentry="[Warning] Failed to refresh harbour-storeman-obs repository, because error-code $retc was returned by: $logentry"
+    printf '\n%s\n' "$(date -Iseconds) $logentry" >> "$logfile" || true
+    printf '%s\n' "$logentry" | systemd-cat -t "$called" -p 5 || true
+    logentry="[Info] Trying to terminate (i.e., sending SIGTERM to) all processes named (ID) `pkcon`, then sleeping for $wait seconds."
+    printf '\n%s\n' "$(date -Iseconds) $logentry" >> "$logfile" || true
+    systemd-cat -t "$called" -p 6 printf '%s\n' "$logentry" || true
+    killall -q -TERM pkcon || true
+    sleep $wait
+    logentry="[Info] Retry #$i"
+    printf '\n%s\n' "$(date -Iseconds) $logentry" >> "$logfile" || true
+    systemd-cat -t "$called" -p 6 printf '%s\n' "$logentry" || true
+  elif [ $i -lt $maxi ]
+  then
+    logentry="[Error] Failed to refresh harbour-storeman-obs repository, because error-code $retc was returned by: $logentry"
+    printf '\n%s\n' "$(date -Iseconds) $logentry" >> "$logfile" || true
+    printf '%s\n' "$logentry" | systemd-cat -t "$called" -p 4 || true
+    logentry="[Warning] Trying to interrupt (i.e., sending SIGINT to) all processes named (ID) `pkcon`, then sleeping for $wait seconds."
+    printf '\n%s\n' "$(date -Iseconds) $logentry" >> "$logfile" || true
+    systemd-cat -t "$called" -p 7 printf '%s\n' "$logentry" || true
+    killall -q -INT pkcon || true
+    sleep $i
+    killall -q -TERM pkcon || true
+    sleep $i
+    logentry="[Info] Retry #$i"
+    printf '\n%s\n' "$(date -Iseconds) $logentry" >> "$logfile" || true
+    systemd-cat -t "$called" -p 6 printf '%s\n' "$logentry" || true
+  else
+    logentry="[Error] Failed to refresh harbour-storeman-obs repository, because error-code $retc was returned by: $logentry"
+    printf '\n%s\n' "$(date -Iseconds) $logentry" >> "$logfile" || true
+    printf '%s\n' "$logentry" | systemd-cat -t "$called" -p 4 || true
+    logentry="[Warning] Trying to hang-up (i.e., sending SIGHUP to) all processes named (ID) `pkcon`, then sleeping for $i seconds and ultimately killing them."
+    printf '\n%s\n' "$(date -Iseconds) $logentry" >> "$logfile" || true
+    systemd-cat -t "$called" -p 7 printf '%s\n' "$logentry" || true
+    killall -q -HUP pkcon || true
+    sleep $i
+    killall -qw -KILL pkcon || true
+    sleep 1
+    systemctl stop packagekit.service || true
+    sleep 1
+    systemctl start packagekit.service || true
+    sleep 1
+    logentry="[Info] Final retry #$i"
+    printf '\n%s\n' "$(date -Iseconds) $logentry" >> "$logfile" || true
+    systemd-cat -t "$called" -p 6 printf '%s\n' "$logentry" || true
+    logentry="pkcon -pv repo-set-data harbour-storeman-obs refresh-now true"
+    printf '\n%s\n' "$(date -Iseconds) [Step 1 / 2] $logentry" >> "$logfile" || true
+    systemd-cat -t "$called" -p 7 printf '%s\n' "[Debug] Execute: $logentry" || true
+    eval $logentry >> "$logfile" 2>&1 && break  # Was final try successful?
+    logentry="[Critical] Failed to refresh harbour-storeman-obs repository, because error-code $retc was returned by: $logentry"
+    printf '\n%s\n' "$(date -Iseconds) $logentry" >> "$logfile" || true
+    printf '%s\n' "$logentry" | systemd-cat -t "$called" -p 3 || true
+    killall -qw -KILL pkcon || true
+    sleep 1
+    systemctl stop packagekit.service || true
+    sleep 1
+    systemctl start packagekit.service || true
+    logentry="[Info] Trying to install harbour-storeman despite the failed repository refresh."
+    printf '\n%s\n' "$(date -Iseconds) $logentry" >> "$logfile" || true
+    systemd-cat -t "$called" -p 6 printf '%s\n' "$logentry" || true
+    sleep 1
+  fi
+done
+logentry="pkcon -pvy install harbour-storeman"
+printf '\n%s\n' "$(date -Iseconds) [Step 2 / 2] $logentry" >> "$logfile" || true
+systemd-cat -t "$called" -p 7 printf '%s\n' "[Debug] Execute: $logentry" || true
+# Sleeping again for a second right before the next pkcon call, because pkcon
+# *rarely* fails installing a package ("not found") immediately after an
+# individual repository refresh via `repo-set-data <repo> refresh-now true`.
+# The following statement must be started fully detached ("double fork" /
+# "daemonize": first a detached sub shell, in which pwd, umask might and
+# session-id must be set anew (i.e., the execution environment), then again
+# the command proper to run as new session-leader), because this script file
+# will be removed in the process, which will likely fail, if it is still
+# opened for executing / reading.
+# It also shall always be the last command issued (WRT control-flow).
+setsid --fork /bin/sh -c '(kill "$PPID"; sleep 1; i=0; while [ $i -lt 9 ] && ps -eo pid | grep -Fq "$1"; do sleep 1; i=$(expr $i + 1); done; eval $2 >> "$3" 2>&1 < /dev/null) &' sh_do_storeman-installer "$mypid" "$logentry" "$logfile" >> "$logfile" 2>&1 < /dev/null || true
+# "Daemonizing" / double-forking ("SysV-style") in Shell code, (ab)using
+# this interpreter instance as first fork.
+# PWD and umask do not need to be set anew here, see line 9.
+exit $retc
+

--- a/bin/harbour-storeman-installer
+++ b/bin/harbour-storeman-installer
@@ -31,20 +31,20 @@ mypid="$$"
 called="$(basename "$0")"
 logfile="/var/log/${called}.log.txt"
 
-umask 7113  # The first octal digit is ignored by most implementations
+umask 7111  # The first octal digit is ignored by most implementations
 [ "$PWD" = /tmp ] || cd /tmp  # Set PWD to /tmp
 
 # Prefix first output with three linebreaks, if logfile size > 0
 linebreaks=""
 if [ -s "$logfile" ]
-then linebreaks="\n\n\n"
+then linebreaks="\n\n------------------------------------------------------------------------------------------------------------\n\n\n"
 fi
 
 # Write first entry to logfile:
-logentry="[Info] Logging to $logfile"
+logentry="[Info] PID $mypid is logging to $logfile"
 if printf "${linebreaks}%s\n" "$(date -Iseconds) $logentry" >> "$logfile"
 then printf '%s\n' "$logentry" | systemd-cat -t "$called" -p 6 || true
-else systemd-cat -t "$called" -p 4 printf '%s\n' "[Error] $pkgname failed to write to $logfile" || true
+else systemd-cat -t "$called" -p 4 printf '%s\n' "[Warning] PID $mypid failed to write to $logfile" || true
 fi
 
 # Even when started interactively, another pkcon job may have just been
@@ -73,7 +73,7 @@ for i in $(seq $maxi)
 do
   logentry="pkcon -pv repo-set-data harbour-storeman-obs refresh-now true"
   printf '\n%s\n' "$(date -Iseconds) [Step 1 / 2] $logentry" >> "$logfile" || true
-  systemd-cat -t "$called" -p 7 printf '%s\n' "[Debug] Execute: $logentry" || true
+  systemd-cat -t "$called" -p 6 printf '%s\n' "[Info] Executing: $logentry" || true
   eval $logentry >> "$logfile" 2>&1
   retc=$?
   wait=$(expr $i \* 2 + 1)
@@ -81,7 +81,7 @@ do
   then break  # Went fine
   elif [ $i = 1 ]
   then
-    logentry="[Warning] Failed to refresh harbour-storeman-obs repository, because error-code $retc was returned by: $logentry"
+    logentry="[Notice] Failed to refresh harbour-storeman-obs repository, because error-code $retc was returned by: $logentry"
     printf '\n%s\n' "$(date -Iseconds) $logentry" >> "$logfile" || true
     printf '%s\n' "$logentry" | systemd-cat -t "$called" -p 5 || true
     logentry="[Debug] Sleeping for $wait seconds."
@@ -95,10 +95,10 @@ do
   then
     logentry="[Warning] Failed to refresh harbour-storeman-obs repository, because error-code $retc was returned by: $logentry"
     printf '\n%s\n' "$(date -Iseconds) $logentry" >> "$logfile" || true
-    printf '%s\n' "$logentry" | systemd-cat -t "$called" -p 5 || true
-    logentry="[Info] Trying to terminate (i.e., sending SIGTERM to) all processes named (ID) `pkcon`, then sleeping for $wait seconds."
+    printf '%s\n' "$logentry" | systemd-cat -t "$called" -p 4 || true
+    logentry="[Notice] Trying to terminate (i.e., sending SIGTERM to) all processes named (ID) `pkcon`, then sleeping for $wait seconds."
     printf '\n%s\n' "$(date -Iseconds) $logentry" >> "$logfile" || true
-    systemd-cat -t "$called" -p 6 printf '%s\n' "$logentry" || true
+    systemd-cat -t "$called" -p 5 printf '%s\n' "$logentry" || true
     killall -q -TERM pkcon || true
     sleep $wait
     logentry="[Info] Retry #$i"
@@ -108,10 +108,10 @@ do
   then
     logentry="[Error] Failed to refresh harbour-storeman-obs repository, because error-code $retc was returned by: $logentry"
     printf '\n%s\n' "$(date -Iseconds) $logentry" >> "$logfile" || true
-    printf '%s\n' "$logentry" | systemd-cat -t "$called" -p 4 || true
+    printf '%s\n' "$logentry" | systemd-cat -t "$called" -p 3 || true
     logentry="[Warning] Trying to interrupt (i.e., sending SIGINT to) all processes named (ID) `pkcon`, then sleeping for $wait seconds."
     printf '\n%s\n' "$(date -Iseconds) $logentry" >> "$logfile" || true
-    systemd-cat -t "$called" -p 7 printf '%s\n' "$logentry" || true
+    systemd-cat -t "$called" -p 4 printf '%s\n' "$logentry" || true
     killall -q -INT pkcon || true
     sleep $i
     killall -q -TERM pkcon || true
@@ -122,10 +122,10 @@ do
   else
     logentry="[Error] Failed to refresh harbour-storeman-obs repository, because error-code $retc was returned by: $logentry"
     printf '\n%s\n' "$(date -Iseconds) $logentry" >> "$logfile" || true
-    printf '%s\n' "$logentry" | systemd-cat -t "$called" -p 4 || true
+    printf '%s\n' "$logentry" | systemd-cat -t "$called" -p 3 || true
     logentry="[Warning] Trying to hang-up (i.e., sending SIGHUP to) all processes named (ID) `pkcon`, then sleeping for $i seconds and ultimately killing them."
     printf '\n%s\n' "$(date -Iseconds) $logentry" >> "$logfile" || true
-    systemd-cat -t "$called" -p 7 printf '%s\n' "$logentry" || true
+    systemd-cat -t "$called" -p 4 printf '%s\n' "$logentry" || true
     killall -q -HUP pkcon || true
     sleep $i
     killall -qw -KILL pkcon || true
@@ -134,30 +134,30 @@ do
     sleep 1
     systemctl start packagekit.service || true
     sleep 1
-    logentry="[Info] Final retry #$i"
+    logentry="[Notice] Final retry #$i"
     printf '\n%s\n' "$(date -Iseconds) $logentry" >> "$logfile" || true
-    systemd-cat -t "$called" -p 6 printf '%s\n' "$logentry" || true
+    systemd-cat -t "$called" -p 5 printf '%s\n' "$logentry" || true
     logentry="pkcon -pv repo-set-data harbour-storeman-obs refresh-now true"
     printf '\n%s\n' "$(date -Iseconds) [Step 1 / 2] $logentry" >> "$logfile" || true
-    systemd-cat -t "$called" -p 7 printf '%s\n' "[Debug] Execute: $logentry" || true
+    systemd-cat -t "$called" -p 6 printf '%s\n' "[Info] Executing: $logentry" || true
     eval $logentry >> "$logfile" 2>&1 && break  # Was final try successful?
     logentry="[Critical] Failed to refresh harbour-storeman-obs repository, because error-code $retc was returned by: $logentry"
     printf '\n%s\n' "$(date -Iseconds) $logentry" >> "$logfile" || true
-    printf '%s\n' "$logentry" | systemd-cat -t "$called" -p 3 || true
+    printf '%s\n' "$logentry" | systemd-cat -t "$called" -p 2 || true
     killall -qw -KILL pkcon || true
     sleep 1
     systemctl stop packagekit.service || true
     sleep 1
     systemctl start packagekit.service || true
-    logentry="[Info] Trying to install harbour-storeman despite the failed repository refresh."
+    logentry="[Notice] Trying to install harbour-storeman despite the failed repository refresh."
     printf '\n%s\n' "$(date -Iseconds) $logentry" >> "$logfile" || true
-    systemd-cat -t "$called" -p 6 printf '%s\n' "$logentry" || true
+    systemd-cat -t "$called" -p 5 printf '%s\n' "$logentry" || true
     sleep 1
   fi
 done
 logentry="pkcon -pvy install harbour-storeman"
 printf '\n%s\n' "$(date -Iseconds) [Step 2 / 2] $logentry" >> "$logfile" || true
-systemd-cat -t "$called" -p 7 printf '%s\n' "[Debug] Execute: $logentry" || true
+systemd-cat -t "$called" -p 6 printf '%s\n' "[Info] Executing: $logentry" || true
 # Sleeping again for a second right before the next pkcon call, because pkcon
 # *rarely* fails installing a package ("not found") immediately after an
 # individual repository refresh via `repo-set-data <repo> refresh-now true`.
@@ -167,10 +167,14 @@ systemd-cat -t "$called" -p 7 printf '%s\n' "[Debug] Execute: $logentry" || true
 # the command proper to run as new session-leader), because this script file
 # will be removed in the process, which will likely fail, if it is still
 # opened for executing / reading.
-# It also shall always be the last command issued (WRT control-flow).
+# It also shall always be the last command issued (WRT control-flow),
+# except for the final log message.
 setsid --fork /bin/sh -c '(kill "$PPID"; sleep 1; i=0; while [ $i -lt 9 ] && ps -eo pid | grep -Fq "$1"; do sleep 1; i=$(expr $i + 1); done; eval $2 >> "$3" 2>&1 < /dev/null) &' sh_do_storeman-installer "$mypid" "$logentry" "$logfile" >> "$logfile" 2>&1 < /dev/null || true
 # "Daemonizing" / double-forking ("SysV-style") in Shell code, (ab)using
 # this interpreter instance as first fork.
-# PWD and umask do not need to be set anew here, see line 9.
+# PWD and umask do not need to be set anew here, see lines 34 and 35.
+logentry="[Debug] ${called}'s main script (PID: ${mypid}) finishes"
+printf '\n%s\n' "$(date -Iseconds) $logentry" >> "$logfile" || true
+systemd-cat -t "$called" -p 7 printf '%s\n' "$logentry" || true
 exit $retc
 

--- a/bin/harbour-storeman-installer
+++ b/bin/harbour-storeman-installer
@@ -38,16 +38,21 @@ fi
 
 # Write first entry to logfile:
 logentry="[Info] Touch'ed logfile: $logfile"
-if printf '%s\n' "$(date -Iseconds)  $logentry" >> "$logfile"
+if printf '%s\n' "$(date -Iseconds) $logentry" >> "$logfile"
 then printf '%s\n' "$logentry" | systemd-cat -t "$called" -p 6 || true
 else printf '%s\n' "[Error] Failed to write to $logfile" | systemd-cat -t "$called" -p 4 || true
 fi
+
+# Even when started interactively, another pkcon job may have just been
+# started, hence provide pkcon with a little time to enqueue it, because
+# otherwise pkcon might fail enqueuing the next pkcon-job.
+sleep 1
 
 # `pkcon repo-set-data` is also intended to serve as a synchronisation
 # point, because most of pkcon's sub-commands wait until the package
 # management backend (on SailfishOS: RPM via libzypp) is idle:
 logentry="pkcon -pv repo-set-data harbour-storeman-obs refresh-now true"
-printf '\n%s\n' "$(date -Iseconds)  $logentry" >> "$logfile" || true
+printf '\n%s\n' "$(date -Iseconds) [Step 1 / 2] $logentry" >> "$logfile" || true
 printf '%s\n' "[Debug] Execute: $logentry" | systemd-cat -t "$called" -p 7 || true
 if eval $logentry >> "$logfile" 2>&1
 then
@@ -56,7 +61,7 @@ then
   # repository refresh via `repo-set-data <repo> refresh-now true`:
   sleep 1
   logentry="pkcon -pvy install harbour-storeman"
-  printf '\n%s\n' "$(date -Iseconds)  $logentry" >> "$logfile" || true
+  printf '\n%s\n' "$(date -Iseconds) [Step 2 / 2] $logentry" >> "$logfile" || true
   printf '%s\n' "[Debug] Execute: $logentry" | systemd-cat -t "$called" -p 7 || true
   # The following statement must be started detached ("&"), because this
   # script file will be removed in the process, which will likely fail,
@@ -65,6 +70,6 @@ then
   eval $logentry >> "$logfile" 2>&1 &
 else
   logentry="[Critical] Aborting to install harbour-storeman, because error-code $? was returned by: $logentry"
-  printf '\n%s\n\n\n' "$(date -Iseconds)  $logentry" >> "$logfile" || true
+  printf '\n%s\n\n\n' "$(date -Iseconds) $logentry" >> "$logfile" || true
   printf '%s\n' "$logentry" | systemd-cat -t "$called" -p 3 || true
 fi

--- a/bin/harbour-storeman-installer
+++ b/bin/harbour-storeman-installer
@@ -1,4 +1,70 @@
 #!/bin/sh
+set -u  # Do not use "-f" (disable pathname expansion) and "-C" (no-clobber /
+# -overwrite), as this script does not potentially need that (yet).
+# Also drop "-e" for now, as it helps and hinders different aspects of debugging.
+#set -o pipefail  # Not used (yet), hence also dropping interpreter #!/bin/bash
+#export POSIXLY_CORRECT=1  # Leave it for now, can have side-effects (positive and negative), apparently not needed (yet).
+export LC_ALL=POSIX  # For details see https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap08.html#tag_08_02
 
-pkcon -pn repo-set-data harbour-storeman-obs refresh-now true
-pkcon -pny install harbour-storeman
+# Specify bash as interpreter of this script (in its first line), as this ensures
+# that "-o pipefail" is available (for its use in the third line), after checking
+# that bash seems to be present in mer-core at least since 2011-10-04 (see
+# https://github.com/sailfishos/mer-core/bash / https://git.merproject.org/mer-core/bash )
+# and consequently in SailfishOS since its beginnings (checked v1.0.0.5 per
+# curl https://releases.sailfishos.org/sources/sailfish-1.0.0.5-oss.tar.bz2 | tar -tv | fgrep bash
+# , as no earlier released version is available there, e.g. the first ones at
+# https://coderus.openrepos.net/whitesoft/sailversion ).
+# In SailfishOS releases before 4.0, /bin/sh is just a symbolic link to /bin/bash
+# anyway.  Since SailfishOS 4.0, the busybox variant of ash has become the shell
+# installed by default, which provides some bash compatibility (implicitly, when
+# called via its bash-symlink, which is deployed by the busybox-symlinks-bash
+# RPM), including "-o pipefail", but not "-o posix"; although setting
+# POSIXLY_CORRECT instead seems to achive the same without compatibility issues,
+# plus (when exported) also for a number of other GNU utilities.
+# Nevertheless, this script is still a Bourne (not-"Again") Shell script and
+# shall stay free of bashisms.
+
+# This script is designed to be called as detached ("&") as the last statement
+# of the %posttrans section (the last executed) of an RPM spec file, or manually.
+
+# Memorise how we were called:
+called="$(basename "$0")"
+
+# If logfile is already there, update its timestamp(s), else create it:
+logfile="/var/log/${called}.log.txt"
+if ! touch "$logfile"
+then printf '%s\n' "[Error] Failed to touch logfile $logfile" | systemd-cat -t "$called" -p 4 || true
+fi
+
+# Write first entry to logfile:
+logentry="[Info] Touch'ed logfile: $logfile"
+if printf '%s\n' "$(date -Iseconds)  $logentry" >> "$logfile"
+then printf '%s\n' "$logentry" | systemd-cat -t "$called" -p 6 || true
+else printf '%s\n' "[Error] Failed to write to $logfile" | systemd-cat -t "$called" -p 4 || true
+fi
+
+# `pkcon repo-set-data` is also intended to serve as a synchronisation
+# point, because most of pkcon's sub-commands wait until the package
+# management backend (on SailfishOS: RPM via libzypp) is idle:
+logentry="pkcon -pv repo-set-data harbour-storeman-obs refresh-now true"
+printf '\n%s\n' "$(date -Iseconds)  $logentry" >> "$logfile" || true
+printf '%s\n' "[Debug] Execute: $logentry" | systemd-cat -t "$called" -p 7 || true
+if eval $logentry >> "$logfile" 2>&1
+then
+  # Sleeping for a second between the two pkcon calls, because pkcon *rarely*
+  # fails installing a package ("not found") immediately after a individual
+  # repository refresh via `repo-set-data <repo> refresh-now true`:
+  sleep 1
+  logentry="pkcon -pvy install harbour-storeman"
+  printf '\n%s\n' "$(date -Iseconds)  $logentry" >> "$logfile" || true
+  printf '%s\n' "[Debug] Execute: $logentry" | systemd-cat -t "$called" -p 7 || true
+  # The following statement must be started detached ("&"), because this
+  # script file will be removed in the process, which will likely fail,
+  # if it is still opened for executing / reading.
+  # It also shall always be the last command issued (WRT control-flow).
+  eval $logentry >> "$logfile" 2>&1 &
+else
+  logentry="[Critical] Aborting to install harbour-storeman, because error-code $? was returned by: $logentry"
+  printf '\n%s\n\n\n' "$(date -Iseconds)  $logentry" >> "$logfile" || true
+  printf '%s\n' "$logentry" | systemd-cat -t "$called" -p 3 || true
+fi

--- a/double-fork-in-shell-code.md
+++ b/double-fork-in-shell-code.md
@@ -6,7 +6,7 @@ This is the "generic form", the strictly static elements are the sequence:<br />
 `setsid --fork sh -c '(<cmd-list_or_script-call_which_does: kill $PPID>) &'`
 
 ## Variations
-- The environment is copied down through the call chain with all shell implemetations (as usual), *except* across the `setsid --fork sh -c ' '` sequence, for which a fresh default environment might be provided (e.g., when a different shell executable is called by setsid than the callers shell).<br />
+- The environment is copied down through the call chain with all shell implementations (as usual), *except* across the `setsid --fork sh -c ' '` sequence, for which a fresh default environment might be provided (e.g., when a different shell executable is called by setsid than the callers shell).<br />
   Hence the safe way to carry parameters across this sequence down the call chain are positional parameters, as described in the man-page of the shell of your choice for the option `-c`.<br />
   Also note that all shells must copy their environment to sub-shells opened with `( )` and commands run in a sub-shell (what most shells do for every shell-external command), additionally some shells also copy their regular variables (the ones not exported to the environment) down to sub-shells opened with `( )`, but this is implementation dependent.
 - One can set the "inner" umask and PWD (via `cd`) as it fits best: The exemplary values in the "generic form" are just often used values; I often set the umask more restrictively.<br />

--- a/double-fork-in-shell-code.md
+++ b/double-fork-in-shell-code.md
@@ -1,0 +1,82 @@
+# Double-fork in shell code
+
+`(kill $PPID; umask 0022; cd /; setsid --fork sh -c '(kill $PPID; umask 0022; cd /; <command-list-to-execute [$1,$2,…]> [redirections-for-a-command]) > /dev/null 2>&1 < /dev/null &' <arbitrary-name-for-$0-"inside"-sh-c> <parameter1-for-$1-"inside"-sh-c> <parameter2-for-$2-"inside"-sh-c> …) & > /dev/null 2>&1 < /dev/null`
+
+This is the "generic form", the strictly static elements are the sequence:<br />
+`setsid --fork sh -c '(<cmd-list_or_script-call_which_does: kill $PPID>) &'`
+
+## Variations
+- The environment is copied down through the call chain with all shell implemetations (as usual), *except* across the `setsid --fork sh -c ' '` sequence, for which a fresh default environment might be provided (e.g., when a different shell executable is called by setsid than the callers shell).<br />
+  Hence the safe way to carry parameters across this sequence down the call chain are positional parameters, as described in the man-page of the shell of your choice for the option `-c`.<br />
+  Also note that all shells must copy their environment to sub-shells opened with `( )` and commands run in a sub-shell (what most shells do for every shell-external command), additionally some shells also copy their regular variables (the ones not exported to the environment) down to sub-shells opened with `( )`, but this is implementation dependent.
+- One can set the "inner" umask and PWD (via `cd`) as it fits best: The exemplary values in the "generic form" are just often used values; I often set the umask more restrictively.<br />
+  Note that the directory to change into must exist (you do not want a `cd` at this point to fail), hence `/` is a safe value, as e.g., `/tmp` is not available early in the boot-phase (not relevant for actions triggered by a regular user).
+- One sure can redirect from or to anywhere else than `/dev/null` or redirect StdIN and StdERR differently.
+- With a proper POSIX-compliant shell, one can close any file descriptor with "-", e.g., for StdIN `>&-`, instead of redirecting it from or to `/dev/null`.<br />
+  But e.g., busybox's ash is not POSIX-compliant.<br />
+  Also note that when closing StdOUT or StdERR, anything writing to a closed file descriptor will (/ might / should / must?  POSIX might tell.) fail, just as reading from a closed StdIN, in contrast to redirections to `/dev/null`.  This is fine if one ensures that the commands executed do not use any closed file descriptors.
+
+## Notes
+- It is strongly recommended to explicitly set StdIN, StdOUT and StdERR to known good values (or ensure that they are sane, already), both for the "outer" / topmost sub-shell and right "inside" the `sh -c ' '`, because they are part of the environment (which is then copied down further), as depicted in the "generic form" above.
+- The innermost / bottom fork is only deemed necessary on System V descendent UNIXes, for the command-list being executed in a shell, which is *not* a session leader (see section "[Background](#background)" below).  Hence on BSD-UNIXes one may omit the innermost `(kill $PPID; <cmd-list>) &` and use `… setsid --fork sh -c '<cmd-list>' …` (or for a single command: `… setsid --fork <command> <arg1> <arg2> …`) instead.  Well, Linux is a System V UNIX by design, but all code is newly and independently written, in contrast to, e.g., HP-UX, IRIX, Sinix etc. (Solaris2?), which contain code from the original System V Release 4 ("SVR4").  I have not researched much, which property "System V descendent UNIX" addresses and how real the dangers are, because once the scheme of double-forking in shell code is understood, it is easy to perform another fork by `(kill $PPID; <cmd-list>) &`, so I went this way.
+- For terminating a (sub-) shell via `SIGTERM`, this shell must not be an interactive shell (POSIX requires interactive shell instances to ignore a `SIGTERM`).  Thus for experimenting / testing in an interactive shell, one might wrap the whole "generic form" (or a variation of it) in another `sh -c ' '`.
+- The caller of the "generic form" is terminated immediately after calling it.  One can think of other ways to ensure that execution of the original caller ends, e.g., see "[Larger variations](#larger-variations)", below.
+- The outer and inner sub-shell must be started detached (by an appended ` &`), otherwise their parent would be stopped during the execution within that sub-shell, hence the caller would not be able to receive and handle the `SIGTERM` sent to it by `kill`.
+- The explicit use of a sub-shell may be superfluous in some special cases: IMHO all shells start a single detached command (i.e., `<cmd> <args> <redirs> &`) automatically in a sub-shell, many execute all external commands in a sub-shell etc., but there may be cases in which this assumption will fall short.<br />
+  Plus, expressing the execution in a sub-shell explicitly never does harm, improves readability (one does not have to know / think about the specific shell's automatisms) and enhances portability.
+- Real double-forking / daemonising (including the "anti-session-leader extra-fork" for SysV-UNIXes) is impossible to achieve via `nohup <command> <args> <redirs> &` or `(<cmd-list>) & disown [-h] $!`
+- Do check that the process hierarchy looks as it should (see section "[Background](#background)" below); the tree-view of GNU-`ps` (option `--forest`) or `pstree` are quite useful to see the hierarchical aspects much easier.  To observe the dynamics of these action and or short running, fully detached processes, this can be best achieved by instrumenting the calling and called script with `ps -o stat,tty,user,group,pgid,sid,ppid,pid,comm,args`, plus appropriate, not too tight filtering (e.g., `ps -eo … | grep …` etc.) and output redirection to a file (e.g., `>> mylog.txt`).  See [this branch for an example](https://github.com/storeman-developers/harbour-storeman-installer/tree/2.0.44), the minimalistic `ps` calls are used in order to be able to work with busybox's `ps` implementation (which is also not POSIX compliant).
+
+## Larger variations
+- Because one usually starts the whole double-fork to the innermost \<command-list\> or \<script-call\> from a shell (respectively, a script running in one), which is not intended to be terminated by an external trigger (here: from a detached shell process it just started), one can (ab)use the shell from which the double fork is called as first fork, if it is known to finish soon.  This has to checked for by the callee, thus it needs that PID to be handed down (specifically across the `setsid --fork sh -c ' '` sequence).  Hence one might use in the calling shell:
+  ```
+  …
+  umask 0022
+  [ "$PWD" = /tmp ] || cd /tmp  # Set PWD to /tmp
+  setsid --fork sh -c '(kill $PPID; umask 0022; [ "$PWD" = /tmp ] || cd /tmp; <Wait for process with PID $1 to die>; <cmd-list [$2]> [redirs-for-a-cmd]) > /dev/null 2>&1 < /dev/null &' <name-for-$0> $$ <param2-for-$2> > /dev/null 2>&1 < /dev/null
+  exit 0
+  ```
+  A "real-life example" [can be seen here](https://github.com/storeman-developers/harbour-storeman-installer/blob/2.0.45/bin/harbour-storeman-installer#L147).
+- Because a long \<command-list\> "inside" the `sh -c ' '` is not nice to handle and maintain, one can simply put the \<command-list\> in a shell script (which might consume positional parameters) and call that via `setsid --fork sh -c '(myscript $1 $2 …) > /dev/null 2>&1 < /dev/null &' <name-for-$0> $$ <param2-for-$2> > /dev/null 2>&1 < /dev/null.  `myscript` should then perform the necessary actions, e.g. (continuing to use the example introduced one bullet point above):
+  ```
+  #!/bin/sh
+  kill $PPID
+  umask 0022
+  [ "$PWD" = /tmp ] || cd /tmp  # Set PWD to /tmp
+  <Wait for process with PID $1 to die>
+  <cmd-list [$2]>
+  …
+  ```
+  A "real-life example" [can be seen here](https://github.com/storeman-developers/harbour-storeman-installer/blob/2.0.45/bin/harbour-storeman-installer#L31) with the [\<Wait for process with PID $1 to die\>](https://github.com/storeman-developers/harbour-storeman-installer/blob/2.0.45/bin/harbour-storeman-installer#L55) further down in this shell script.
+
+## Background
+### My issue: To trigger the installation of an rpm from a scriptlet of another one
+I had to trigger the installation of an rpm package from within an spec file scriptlet of an "installer" rpm package, for which the `%posttrans` scriptlet is the natural place, as it is run last.  Side note: In general this should not be necessary, my initial reaction also was "this is conceptually wrong and shall be handled by proper dependency definitions", but it turned out to be a special case with restrictions which do create a necessity for this; other workarounds would be much harder to deploy for an average user.  Here, the "installer" package has to enable an appropriate, dynamically determined repository (dependent on CPU-architecture, installed OS release etc.) in order to access the correct main package; before this repository is not enabled, i.e., before the installation of the "installer" package has not finished, resolving dependencies for a main package cannot be performed, because the (/ any) specific main package is not yet accessible.
+
+I know that other people have solved this by utilising `cron` or `systemd`, but after having successfully [implemented this via an indirection by a systemd unit](https://github.com/storeman-developers/harbour-storeman-installer/tree/2.0.31/), I realised:
+- The indirection via `cron` or `systemd` achieves that the started process is fully detached from the caller: I.e., that the caller is not an ancestor (parent, grandparent etc.) of the callee, plus that it is run within a different session (see `ps`'s field `sid` for the SessionID) and hence does not share a TTY with the caller, any longer.
+- One does not want any time-based waiting, because no one can tell how long the initial "installer" package installation will take on a non-deterministic software stack (i.e., not a real-time system); imagine a machine is heavily swapping and hence (almost) grinding to a halt.  Thus timer units or cron jobs are not suitable to implement this robustly.
+- Consequently one has to transmit the PID of the `%posttrans` scriptlet interpreter (usually `bash`) to the fully detached process, when it is instanciated, so it can wait for the `%posttrans` interpreter to finish execution of the scriptlet.  Systemd allows for a single parameter to be transmitted to "instanciated units", but the wait function (a `while` or `until` loop) has to be implemented in an external script called by an `ExecStartPre=` statement (or pack the whole wait function awkwardly in an `sh -c ' '`), because systemd does not allow for loops or any other kind of program flow control.
+- That was the moment I realised that a single, own shell script is more elegant and provides one with many more degrees of freedom than being limited to systemd's unit syntax.  The only open design question was then how to become fully detached from the caller.  I remembered the concept of double-forking / "daemonizing" for UNIX daemons, which were once usually written in C, to fully detach a process from its caller.
+- The final twist for a robust implementation was [to trigger the installation of the main package also in a fully detached manner by double-forking, then waiting for the grandparent to finish (i.e., the installer script)](https://github.com/storeman-developers/harbour-storeman-installer/blob/2.0.45/bin/harbour-storeman-installer#L192), because the main package automatically triggers the removal of the "installer" package (including its "installer" script) by a `Conflicts:` dependency on it.  This way the main package can be kept free of any special measures WRT the two stepped installation procedure (except for the single `Conflicts: <installer>` statement) and hence also can be manually and directly installed and removed after manually enabling the correct repository or downloading a suitable rpm package.
+
+### General information about various aspects of double-forking / "daemonize"
+Hence I started searching the WWW for how to perform a double-fork in shell code, without finding anything really useful for UNIX shells, but really good explanations and examples in C, Python, Ruby etc.:
+- https://stackoverflow.com/questions/881388/what-is-the-reason-for-performing-a-double-fork-when-creating-a-daemon<br />
+  Good, fruitful discussion of this topic, but relevant information is spread over many posts.
+- https://unix.stackexchange.com/questions/715248/double-fork-why<br />
+  Clean C-based example, plus discussion of the need to *double* fork on System V UNIXes with no concluding result for Linux.
+- https://0xjet.github.io/3OHA/2022/04/11/post.html<br />
+  Very nice and concise "low-level, abstract description" (no conundrum, really well done) of double forking.
+- https://subscription.packtpub.com/book/networking-and-servers/9781784396879/11/ch11lvl1sec73/double-fork-and-setsid<br />
+  This one comes close (the only shell-oriented post worth reading I found), but does only go half the way; unfortunately I found it after having determined that using `setsid` is crucial and looked for application examples.
+- https://gist.github.com/mynameisrufus/1372491#file-simple_daemon-rb-L2<br />
+  Another concise write-up, with example in Ruby.
+- https://news.ycombinator.com/item?id=8355376<br />
+  This discussion confirmed my belief at that point, that (double-)forking is the only way to go.
+
+I wonder, why I have not found any proper and complete example for shell code, because I believe that people must have written UNIX daemons in shell code and also started them this way (e.g., per classic sysv-init), but maybe this was done in the 70s, 80s and 90s when no forums as Stackexchange, Stackoverflow or GitHub-gists etc. existed.<br />
+So I ended up researching, implementing, testing and documenting this for myself and the world.
+<br />
+
+HTH

--- a/rpm/harbour-storeman-installer.spec
+++ b/rpm/harbour-storeman-installer.spec
@@ -6,7 +6,7 @@ Name:           harbour-storeman-installer
 # comprises one of {alpha,beta,rc,release} postfixed with a natural number
 # greater or equal to 1 (e.g., "beta3").  For details and reasons, see
 # https://github.com/storeman-developers/harbour-storeman-installer/wiki/Git-tag-format
-Version:        1.3.4
+Version:        1.3.5
 Release:        release1
 Group:          Applications/System
 URL:            https://github.com/storeman-developers/%{name}
@@ -73,6 +73,9 @@ Url:
 mkdir -p %{buildroot}%{_bindir}
 cp bin/%{name} %{buildroot}%{_bindir}/
 
+mkdir -p %{buildroot}%{_localstatedir}/log
+touch %{buildroot}%{_localstatedir}/log/%{name}.log.txt
+
 mkdir -p %{buildroot}%{_sharedstatedir}/%{localauthority_dir}
 cp %{localauthority_dir}/* %{buildroot}%{_sharedstatedir}/%{localauthority_dir}/
 #mkdir -p %%{buildroot}%%{_sysconfdir}/%%{localauthority_dir}
@@ -118,12 +121,17 @@ fi
 %files
 %defattr(-,root,root,-)
 %attr(0755,root,root) %{_bindir}/%{name}
+%config(noreplace) %attr(0664,root,ssu) %{_localstatedir}/log/%{name}.log.txt
 %{_datadir}/applications/%{name}.desktop
 %{hicolor_icons_dir}/*/apps/%{name}.png
 %{_sharedstatedir}/%{localauthority_dir}/50-%{name}.pkla
 #%%{_sysconfdir}/%%{localauthority_dir}/50-%%{name}.pkla
 
 %changelog
+* Fri Dec 09 2022 olf <Olf0@users.noreply.github.com> - 1.3.5-release1
+- Update `harbor-storeman-installer` script to version in defer-inst-via-detached-script branch (#144)
+- Re-adapt `harbor-storeman-installer` script for interactive use (#144)
+- Log file needs to be writable (#146)
 * Sun Dec 04 2022 olf <Olf0@users.noreply.github.com> - 1.3.4-release1
 - Radically rewrite `harbor-storeman-installer` script in `/usr/bin` (#136)
 - The `harbor-storeman-installer` script ultimately issues `pkcon install harbour-storeman … &` (i.e., also detached), allowing this script to be removed in the process of the Storeman installation

--- a/rpm/harbour-storeman-installer.spec
+++ b/rpm/harbour-storeman-installer.spec
@@ -91,8 +91,8 @@ desktop-file-install --delete-original --dir=%{buildroot}%{_datadir}/application
 # The %%post scriptlet is deliberately run when installing *and* updating.
 # The added harbour-storeman-obs repository is not removed when Storeman Installer
 # is removed, but when Storeman is removed (before it was added, removed, then
-# added again when installing Storeman via Storeman Installer): This is far more
-# fail-safe; if something goes wrong, SSUs repo entry is now ensured to exist.
+# added again when installing Storeman via Storeman Installer), which is far more
+# fail-safe: If something goes wrong, this SSUs repo entry is now ensured to exist.
 ssu_ur='no'
 ssu_lr="$(ssu lr | grep '^ - ' | cut -f 3 -d ' ')"
 if printf '%s' "$ssu_lr" | grep -Fq 'mentaljam-obs'
@@ -119,7 +119,7 @@ fi
 #%%{_sysconfdir}/%%{localauthority_dir}/50-%%{name}.pkla
 
 %changelog
-* Sat Dec 03 2022 olf <https://github.com/Olf0> - 1.3.2-release1
+* Fri Dec 02 2022 olf <https://github.com/Olf0> - 1.3.2-release1
 - Refine %%post section of the spec file (#96)
 * Thu Dec 01 2022 olf <https://github.com/Olf0> - 1.3.1-release1
 - Fix auto-removing Storeman < 0.3.0 on SailfishOS ≥ 3.1.0 (#109)

--- a/rpm/harbour-storeman-installer.spec
+++ b/rpm/harbour-storeman-installer.spec
@@ -6,7 +6,7 @@ Name:           harbour-storeman-installer
 # comprises one of {alpha,beta,rc,release} postfixed with a natural number
 # greater or equal to 1 (e.g., "beta3").  For details and reasons, see
 # https://github.com/storeman-developers/harbour-storeman-installer/wiki/Git-tag-format
-Version:        1.3.6
+Version:        1.3.7
 Release:        release1
 Group:          Applications/System
 URL:            https://github.com/storeman-developers/%{name}
@@ -119,10 +119,10 @@ then
   curmask="$(umask)"
   umask 7022  # The first octal digit is ignored by most implementations
   [ ! -e %{_localstatedir}/log ] && mkdir -p %{_localstatedir}/log
-  umask 7113
+  umask 7111
   touch %{_localstatedir}/log/%{name}.log.txt
   # Not necessary, because umask is set:
-  # chmod 0664 %{_localstatedir}/log/%{name}.log.txt
+  # chmod 0666 %{_localstatedir}/log/%{name}.log.txt
   chgrp ssu %{_localstatedir}/log/%{name}.log.txt
   umask "$curmask"
 fi
@@ -166,12 +166,12 @@ exit 0
 #%%{_sysconfdir}/%%{localauthority_dir}/50-%%{name}.pkla
 
 %changelog
-* Sat Dec 17 2022 olf <Olf0@users.noreply.github.com> - 1.3.6-release1
+* Sat Dec 17 2022 olf <Olf0@users.noreply.github.com> - 1.3.7-release1
 - Set umask and PWD in harbour-storeman-installer script
 - Start installation of harbour-storeman fully detached ("double fork" / daemonize)
 - Print version of harbour-storeman-installer package in the log file entry of each run
 - Consistently set files and limit access to group "ssu"
-- Refactor and enhance failure of: pkcon repo-set-data harbour-storeman-obs refresh-now true  
+- Refactor and enhance failure of: pkcon repo-set-data harbour-storeman-obs refresh-now true
 * Fri Dec 09 2022 olf <Olf0@users.noreply.github.com> - 1.3.5-release1
 - Update `harbour-storeman-installer` script to version in defer-inst-via-detached-script branch (#144)
 - Re-adapt `harbour-storeman-installer` script for interactive use (#144)

--- a/rpm/harbour-storeman-installer.spec
+++ b/rpm/harbour-storeman-installer.spec
@@ -6,7 +6,7 @@ Name:           harbour-storeman-installer
 # comprises one of {alpha,beta,rc,release} postfixed with a natural number
 # greater or equal to 1 (e.g., "beta3").  For details and reasons, see
 # https://github.com/storeman-developers/harbour-storeman-installer/wiki/Git-tag-format
-Version:        1.3.2
+Version:        1.3.3
 Release:        release1
 Group:          Applications/System
 URL:            https://github.com/storeman-developers/%{name}
@@ -33,9 +33,9 @@ Provides:       harbour-storeman = 0.3.0~0
 # This description section includes metadata for SailfishOS:Chum, see
 # https://github.com/sailfishos-chum/main/blob/main/Metadata.md
 %description
-Storeman Installer selects the right variant of the Storeman OpenRepos client
-application built for the CPU-architecture of the device and the installed
-SailfishOS release.
+Storeman Installer selects, downloads and installs the right variant of
+the Storeman OpenRepos client application built for the CPU-architecture
+of the device and its installed SailfishOS release.
 
 %if "%{?vendor}" == "chum"
 PackageName: Storeman Installer for SailfishOS
@@ -93,22 +93,27 @@ desktop-file-install --delete-original --dir=%{buildroot}%{_datadir}/application
 # is removed, but when Storeman is removed (before it was added, removed, then
 # added again when installing Storeman via Storeman Installer), which is far more
 # fail-safe: If something goes wrong, this SSUs repo entry is now ensured to exist.
-ssu_ur='no'
+ssu_ur=no
 ssu_lr="$(ssu lr | grep '^ - ' | cut -f 3 -d ' ')"
-if printf '%s' "$ssu_lr" | grep -Fq 'mentaljam-obs'
+if printf %s "$ssu_lr" | grep -Fq mentaljam-obs
 then
   ssu rr mentaljam-obs
   rm -f /var/cache/ssu/features.ini
-  ssu_ur='yes'
+  ssu_ur=yes
 fi
-if ! printf '%s' "$ssu_lr" | grep -Fq 'harbour-storeman-obs'
+if ! printf %s "$ssu_lr" | grep -Fq harbour-storeman-obs
 then
   ssu ar harbour-storeman-obs 'https://repo.sailfishos.org/obs/home:/olf:/harbour-storeman/%%(release)_%%(arch)/'
-  ssu_ur='yes'
+  ssu_ur=yes
 fi
-if [ "$ssu_ur" = 'yes' ]
+if [ $ssu_ur = yes ]
 then ssu ur
 fi
+# BTW, `ssu`, `rm -f`, `mkdir -p` etc. *always* return with "0" ("success"), hence
+# no appended `|| true` needed to satisfy `set -e` for failing commands outside of
+# flow control directives (if, while, until etc.).  Furthermore on Fedora Docs it
+# is indicated that solely the final exit status of a whole scriptlet is crucial: 
+# https://docs.fedoraproject.org/en-US/packaging-guidelines/Scriptlets/#_syntax
 
 %files
 %defattr(-,root,root,-)
@@ -119,6 +124,10 @@ fi
 #%%{_sysconfdir}/%%{localauthority_dir}/50-%%{name}.pkla
 
 %changelog
+* Sat Dec 03 2022 olf <https://github.com/Olf0> - 1.3.3-release1
+- Start pkcon commands with the options -pn (#130)
+- Tidy spec file as implemented in v2.0 (#130)
+- Clarify comment (#128)
 * Fri Dec 02 2022 olf <https://github.com/Olf0> - 1.3.2-release1
 - Refine %%post section of the spec file (#96)
 * Thu Dec 01 2022 olf <https://github.com/Olf0> - 1.3.1-release1

--- a/rpm/harbour-storeman-installer.spec
+++ b/rpm/harbour-storeman-installer.spec
@@ -6,7 +6,7 @@ Name:           harbour-storeman-installer
 # comprises one of {alpha,beta,rc,release} postfixed with a natural number
 # greater or equal to 1 (e.g., "beta3").  For details and reasons, see
 # https://github.com/storeman-developers/harbour-storeman-installer/wiki/Git-tag-format
-Version:        1.3.3
+Version:        1.3.4
 Release:        release1
 Group:          Applications/System
 URL:            https://github.com/storeman-developers/%{name}
@@ -124,37 +124,41 @@ fi
 #%%{_sysconfdir}/%%{localauthority_dir}/50-%%{name}.pkla
 
 %changelog
-* Sat Dec 03 2022 olf <https://github.com/Olf0> - 1.3.3-release1
+* Sun Dec 04 2022 olf <Olf0@users.noreply.github.com> - 1.3.4-release1
+- Radically rewrite `harbor-storeman-installer` script in `/usr/bin` (#136)
+- The `harbor-storeman-installer` script ultimately issues `pkcon install harbour-storeman … &` (i.e., also detached), allowing this script to be removed in the process of the Storeman installation
+- Do not use pkcon's option -n; it is slow enough (#134)
+* Sat Dec 03 2022 olf <Olf0@users.noreply.github.com> - 1.3.3-release1
 - Start pkcon commands with the options -pn (#130)
 - Tidy spec file as implemented in v2.0 (#130)
 - Clarify comment (#128)
-* Fri Dec 02 2022 olf <https://github.com/Olf0> - 1.3.2-release1
+* Thu Dec 01 2022 olf <Olf0@users.noreply.github.com> - 1.3.2-release1
 - Refine %%post section of the spec file (#96)
-* Thu Dec 01 2022 olf <https://github.com/Olf0> - 1.3.1-release1
+* Wed Nov 30 2022 olf <Olf0@users.noreply.github.com> - 1.3.1-release1
 - Fix auto-removing Storeman < 0.3.0 on SailfishOS ≥ 3.1.0 (#109)
-* Tue Nov 29 2022 olf <https://github.com/Olf0> - 1.3.0-release1
+* Tue Nov 29 2022 olf <Olf0@users.noreply.github.com> - 1.3.0-release1
 - Now should automatically remove an installed Storeman < 0.3.0 when being installed (#95)
 - Enhance multiple aspects of the spec file (#89, #91, #93)
 - Many small enhancements of comments, strings and other non-code assets
 - Storeman Installer ≥ 1.3.0 is a prerequisite for Storeman ≥ 0.3.2
-* Sat Jun 04 2022 olf <https://github.com/Olf0> - 1.2.9-release1
+* Sat Jun 04 2022 olf <Olf0@users.noreply.github.com> - 1.2.9-release1
 - pkcon expects options before the command (#74)
-* Sun May 15 2022 olf <https://github.com/Olf0> - 1.2.8-release1
+* Sun May 15 2022 olf <Olf0@users.noreply.github.com> - 1.2.8-release1
 - Requires: sailfish-version >= 3.1.0 (#61), because this is the oldest SailfishOS release any Storeman version installed by Storeman Installer will work on.
-* Sun Apr 10 2022 olf <https://github.com/Olf0> - 1.2.7-release1
+* Sun Apr 10 2022 olf <Olf0@users.noreply.github.com> - 1.2.7-release1
 - Fix icon deployment
-* Thu Apr 07 2022 olf <https://github.com/Olf0> - 1.2.6-release1
+* Thu Apr 07 2022 olf <Olf0@users.noreply.github.com> - 1.2.6-release1
 - Release tags must not carry a prepended "v" any longer and solely consist of a simple semantic version number a.b.c, because … (see next point)
 - Specify a correct source link at GitHub (#42)
 - Address a couple of rpmlint complaints
 Versions 1.2.3, 1.2.4 and 1.2.5 are unreleased test versions.
-* Sun Mar 20 2022 olf <https://github.com/Olf0> - 1.2.2-1
+* Sun Mar 20 2022 olf <Olf0@users.noreply.github.com> - 1.2.2-1
 - .desktop file: Trivially bail out of SailJail #38
-* Thu Mar 17 2022 olf <https://github.com/Olf0> - 1.2.1-1
+* Thu Mar 17 2022 olf <Olf0@users.noreply.github.com> - 1.2.1-1
 - spec file: Add SailfishOS:Chum metadata (#23) plus spec file: Add categories (#31) and #30
 - Create help-template.md (#24)
 - Create and enhance README (#25, #29, #30, #32, #33, #34, #35)
-* Sun Mar 13 2022 olf <https://github.com/Olf0> - 1.2.0-1
+* Sun Mar 13 2022 olf <Olf0@users.noreply.github.com> - 1.2.0-1
 - Change group from users to ssu
 - polkit: Limit allowed actions to the necessary ones
 - Do not to call Bash

--- a/rpm/harbour-storeman-installer.spec
+++ b/rpm/harbour-storeman-installer.spec
@@ -23,7 +23,7 @@ Requires:       ssu
 # The oldest SailfishOS release Storeman ≥ 0.2.9 compiles for & the oldest available DoD repo at Sailfish-OBS:
 Requires:       sailfish-version >= 3.1.0
 Conflicts:      harbour-storeman
-Obsoletes:      harbour-storeman < 0.3.0
+Obsoletes:      harbour-storeman < 0.2.99
 Provides:       harbour-storeman = 0.3.0~0
 
 %define localauthority_dir polkit-1/localauthority/50-local.d

--- a/rpm/harbour-storeman-installer.spec
+++ b/rpm/harbour-storeman-installer.spec
@@ -129,12 +129,12 @@ fi
 
 %changelog
 * Fri Dec 09 2022 olf <Olf0@users.noreply.github.com> - 1.3.5-release1
-- Update `harbor-storeman-installer` script to version in defer-inst-via-detached-script branch (#144)
-- Re-adapt `harbor-storeman-installer` script for interactive use (#144)
-- Log file needs to be writable (#146)
+- Update `harbour-storeman-installer` script to version in defer-inst-via-detached-script branch (#144)
+- Re-adapt `harbour-storeman-installer` script for interactive use (#144)
+- Log file needs to be writeable (#146)
 * Sun Dec 04 2022 olf <Olf0@users.noreply.github.com> - 1.3.4-release1
-- Radically rewrite `harbor-storeman-installer` script in `/usr/bin` (#136)
-- The `harbor-storeman-installer` script ultimately issues `pkcon install harbour-storeman … &` (i.e., also detached), allowing this script to be removed in the process of the Storeman installation
+- Radically rewrite `harbour-storeman-installer` script in `/usr/bin` (#136)
+- The `harbour-storeman-installer` script ultimately issues `pkcon install harbour-storeman … &` (i.e., also detached), allowing this script to be removed in the process of the Storeman installation
 - Do not use pkcon's option -n; it is slow enough (#134)
 * Sat Dec 03 2022 olf <Olf0@users.noreply.github.com> - 1.3.3-release1
 - Start pkcon commands with the options -pn (#130)


### PR DESCRIPTION
* Delete space at line end in changelog

* Adapt umask and version number (#173)

* Fix typo (#174)

* Align log levels with wording and v2.0.47
  Also fix unbound variable due to copy'o.

* Visually enhance "page-break"

* Enhance epilogue

* Align log levels with wording and v2.0.47 (#172)

* Visually enhance "page-break" (#172)

*  Create log output epilogue (#172)