### PR TITLE
 Shorten build name prefix …

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: CI build on SFOS 3.0.1.11 (armv7hl)
+name: CI on SFOS 3.0.1.11
 
 on:
   push:


### PR DESCRIPTION
… because the term "build" plus the specific trigger is appended to each CI run by an "GitHub action".